### PR TITLE
Add Substack link and fix text color

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -79,5 +79,7 @@ feel free to reach me (16): 6E 40 6E 63 30 2E 66 72 -->
 		<p><a href="https://twitter.com/nc0_fr" target="_blank">twitter</a></p>
 		<p><a href="https://github.com/nc0fr" target="_blank">github</a></p>
 		<p><a href="mailto:n@nc0.fr?subjet=Hi" target="_blank">email</a></p>
+		<p><a href="https://nc0fr.substack.com" target="_blank">
+			substack</a></p>
 	</nav>
 </main>

--- a/src/styles.css
+++ b/src/styles.css
@@ -53,6 +53,7 @@ h1 {
 	text-transform: uppercase;
 	font-size: 150%;
 	letter-spacing: 0.5em;
+	color: #0E9D65;
 }
 
 p {
@@ -62,15 +63,16 @@ p {
 }
 
 p > a {
-	color: #fff;
+	color: #1AA06C;
 	text-decoration: none;
 }
 
 nav {
 	display: flex;
-	align-items: center;
-	justify-content: center;
+	flex-wrap: wrap;
 	gap: 20px;
+	justify-content: center;
+	align-items: center;
 }
 
 img {


### PR DESCRIPTION
This patch list adds a link to my [newsletter and blog on Substack](https://nc0fr.substack.com/) as well as changing the color of texts from pure white (`#fff`) to dark blue.

Closes #3.