### PR TITLE
Add new social links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -78,12 +78,10 @@ feel free to reach me (16): 6E 40 6E 63 30 2E 66 72 -->
 	<nav>
 		<p>
 			<a href="https://twitter.com/nc0_fr" target="_blank">twitter</a>
-			+
-			<a href="https://github.com/nc0fr" target="_blank">github</a>
-			+
-			<a href="mailto:n@nc0.fr?subjet=Hi" target="_blank">email</a>
-			+
-			<a href="https://nc0fr.substack.com" target="_blank">א</a>
+			+ <a href="https://github.com/nc0fr" target="_blank">github</a>
+			+ <a href="mailto:n@nc0.fr?subjet=Hi" target="_blank">email</a>
+			+ <a href="https://nc0fr.substack.com" target="_blank">א</a>
+			+ <a href="https://blog.nc0.fr" target="_blank">blog</a>
 		</p>
 	</nav>
 </main>

--- a/src/index.html
+++ b/src/index.html
@@ -83,7 +83,7 @@ feel free to reach me (16): 6E 40 6E 63 30 2E 66 72 -->
 			+
 			<a href="mailto:n@nc0.fr?subjet=Hi" target="_blank">email</a>
 			+
-			<a href="https://nc0fr.substack.com" target="_blank">substack</a>
+			<a href="https://nc0fr.substack.com" target="_blank">א</a>
 		</p>
 	</nav>
 </main>


### PR DESCRIPTION
This patch list closes two issues related to links:

1. Rename "Substack" to "𐡀" as it is an artistic project as a whole (closes #12);
2. Add link to my [technical blog](https://blog.nc0.fr) (closes #11).